### PR TITLE
Allow using macro without extra dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub use method::Method;
 pub use transaction_id::TransactionId;
 
 #[macro_use]
-mod macros;
+pub mod macros;
 
 pub mod convert;
 pub mod net;


### PR DESCRIPTION
Previously one had to import the macros from `trackable` manually.