### PR TITLE
Relax `Message::add_attribute` argument to `impl Into<A>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 //! # fn main() -> bytecodec::Result<()> {
 //! // Creates a message
-//! let mut message = Message::new(MessageClass::Request, BINDING, TransactionId::new([3; 12]));
-//! message.add_attribute(Attribute::Software(Software::new("foo".to_owned())?));
+//! let mut message = Message::<Attribute>::new(MessageClass::Request, BINDING, TransactionId::new([3; 12]));
+//! message.add_attribute(Software::new("foo".to_owned())?);
 //!
 //! // Encodes the message
 //! let mut encoder = MessageEncoder::new();
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     fn it_works() -> Result<(), MainError> {
         let mut message = Message::new(MessageClass::Request, BINDING, TransactionId::new([3; 12]));
-        message.add_attribute(Attribute::Software(Software::new("foo".to_owned())?));
+        message.add_attribute(Software::new("foo".to_owned()));
 
         let mut encoder = MessageEncoder::new();
         let bytes = encoder.encode_into_bytes(message.clone())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     fn it_works() -> Result<(), MainError> {
         let mut message = Message::new(MessageClass::Request, BINDING, TransactionId::new([3; 12]));
-        message.add_attribute(Software::new("foo".to_owned()));
+        message.add_attribute(Software::new("foo".to_owned())?);
 
         let mut encoder = MessageEncoder::new();
         let bytes = encoder.encode_into_bytes(message.clone())?;

--- a/src/message.rs
+++ b/src/message.rs
@@ -213,8 +213,8 @@ impl<A: Attribute> Message<A> {
     }
 
     /// Adds the given attribute to the tail of the attributes in the message.
-    pub fn add_attribute(&mut self, attribute: A) {
-        self.attributes.push(LosslessAttribute::new(attribute));
+    pub fn add_attribute(&mut self, attribute: impl Into<A>) {
+        self.attributes.push(LosslessAttribute::new(attribute.into()));
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -214,7 +214,8 @@ impl<A: Attribute> Message<A> {
 
     /// Adds the given attribute to the tail of the attributes in the message.
     pub fn add_attribute(&mut self, attribute: impl Into<A>) {
-        self.attributes.push(LosslessAttribute::new(attribute.into()));
+        self.attributes
+            .push(LosslessAttribute::new(attribute.into()));
     }
 }
 


### PR DESCRIPTION
By design, a `Message` is generic over an attribute `A` which is typically represented as an enum. This requires either wrapping the concrete argument you want to add in its parent enum variant or calling `.into()` as a user.

We can make this more ergonomic by relaxing the parameter to `impl Into<A>` and call `.into()` for the user. This allows them to add the attribute directly and it will be converted to the enum for the user.