### PR TITLE
Run CI on `pull_request` event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   check:


### PR DESCRIPTION
Previously, CI would only run on `push`es to branches within this repository. This doesn't work for outside contributors because those PRs are coming from forks and thus don't trigger CI.