### PR TITLE
Remove the hmac_sha1 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ coveralls = {repository = "sile/stun_codec"}
 bytecodec = "0.4"
 byteorder = "1"
 crc = "3"
-hmac-sha1 = "0.1"
+hmac = "0.12.1"
 md5 = "0.7"
+sha1 = "0.10.6"
 trackable = "1"


### PR DESCRIPTION
I am the author of [hmac-sha1](https://github.com/pantsman0/rust-hmac-sha1).
I have updated the project to 0.2 and using the RustCrypto backend.

Given that this is now just a thin wrapper around the RustCrypto project, I am planning to deprecate the project.

This PR removes the dependency to the project and implements there required hmac code in attributes.rs.