### PR TITLE
Update `bytecodec` to v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 coveralls = {repository = "sile/stun_codec"}
 
 [dependencies]
-bytecodec = "0.4"
+bytecodec = "0.5"
 byteorder = "1"
 crc = "3"
 hmac = "0.12.1"


### PR DESCRIPTION
Bumps `bytecodec` to the latest release.